### PR TITLE
Display feed: gate on the source, not the degraded letter (fixes #30)

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -1,0 +1,118 @@
+# Bill of materials
+
+Everything needed to build a station like the reference one. The reference
+station is the machine every measured figure in this repository came from; its
+exact parts are listed in the README's [Hardware](README.md#hardware) section.
+This document is the shopping list version of that table: what is genuinely
+required, what is optional, what may be substituted, and the things that will
+bite you if you buy the obvious alternative.
+
+**On prices.** The figures below are ballpark retail prices in GBP, ex. VAT
+treatment and ex. shipping, given only to convey the scale of the build. They
+were not quoted from any retailer and will be wrong in detail. Check before you
+buy.
+
+**On requirement.** Nothing here is required *by the software*. The station
+discovers what it is attached to and records what it actually negotiated
+(`oo audio probe`). A USB audio device that is not an AudioMoth will capture at
+whatever rate it negotiates; the ultrasonic detector simply has nothing to work
+with below ~96 kHz.
+
+---
+
+## Core station — required
+
+| # | Part | Qty | ~Price | Why this one |
+|---|---|---|---|---|
+| 1 | **Raspberry Pi 5 Model B, 8 GB** | 1 | £75 | Three detectors, a 384 kHz capture thread and the API share one process. 4 GB will probably run it; 8 GB is what was measured. A Pi 4 has not been tried and is not recommended — the capture path is CPU-bound at 384 kHz. |
+| 2 | **AudioMoth USB Microphone** ([Open Acoustic Devices](https://www.openacousticdevices.info/product-page/audiomoth-usb-microphone)) | 1 | £70 | The whole point. A full-spectrum USB mic that negotiates **384 kHz mono `S16_LE`**, putting bats inside the band. USB ID `16d0:06f3`. Buy the *USB Microphone* variant, **not** an AudioMoth recorder — see [Substitutions](#substitutions-and-what-they-cost-you). |
+| 3 | **AudioMoth USB Microphone case** ([official](https://www.openacousticdevices.info/product-page/audiomoth-usb-microphone-case)) | 1 | £10 | The board ships bare. It is going to hang outdoors under an eave. |
+| 4 | **microSD card, 128 GB or larger, A2/V30** | 1 | £15 | OS, application, and the SQLite database. The reference station uses a SanDisk 256 GB. See the endurance warning below. |
+| 5 | **USB SSD, 500 GB** | 1 | £45 | Evidence clips live here, mounted over `data/clips`, deliberately *not* the database (ADR-021). Reference part: SanDisk Extreme Portable (`0781:558c`), USB/UAS. A busy bat night writes gigabytes; size it for your retention policy, not your first week. |
+| 6 | **USB-C power supply, 27 W (5 V 5 A)** | 1 | £12 | The official Raspberry Pi 27 W supply. **Buy this rather than copying the reference station**, which runs on a 5 V 3 A charger and therefore has `usb_max_current_enable=0` — a 600 mA *total* USB budget shared between the SSD and the microphone. It has never faulted here, but an underpowered supply is a genuinely plausible cause of an intermittently-enumerating microphone. 27 W removes the constraint. |
+| 7 | **Micro-USB cable, 2 m** | 1 | £8 | Microphone to Pi. Long enough to reach from indoors to the eaves. Must be a **data** cable, not a charge-only one. Longer runs are untested; USB 2.0 tolerates 5 m in principle. |
+| 8 | **Passive case with a metal body** | 1 | £15 | Reference part: [Flirc Raspberry Pi 5 case](https://thepihut.com/products/flirc-raspberry-pi-5-case). The aluminium body *is* the heatsink and there is **no fan** — which matters, because a fan a metre from an ultrasonic microphone is not a neutral choice. Measured: 39 °C idle, **~58 °C** sustained with capture and three detectors, `throttled=0x0` after nine days up. |
+
+**Networking** is WiFi on the reference station; the Pi's Ethernet port is
+unused. Either works. The station never needs the internet for capture,
+detection, review or query — only for optional model downloads and NTP.
+
+Core subtotal: **roughly £250.**
+
+---
+
+## Indoor display — optional
+
+The "inside observer": an ambient counter-top screen showing what the garden is
+hearing. The station is complete without it.
+
+| # | Part | Qty | ~Price | Notes |
+|---|---|---|---|---|
+| 9 | **ESP32-2432S028R** ("Cheap Yellow Display", Sunton/DIYmalls) | 1 | £15 | 2.8" 240×320 **ILI9341** over SPI, XPT2046 resistive touch, CH340 USB serial, 4 MB flash, **no PSRAM**. The firmware probes the panel at boot; this board also ships in an ST7789 revision, and `firmware/inside-observer/README.md` covers that case. |
+| 10 | **Case for it** | 1 | £2 filament | The reference build uses a [printed case](https://makerworld.com/models/1382304) inherited from the *Aura* project this board had previously been assembled for. |
+| 11 | **USB cable + 5 V supply for the display** | 1 | £8 | Micro-USB. Flashing is over the same cable. |
+
+Display subtotal: **roughly £25.**
+
+---
+
+## Tools and consumables
+
+Not parts, but you will need them.
+
+- **A computer to deploy from.** `deploy/deploy.sh` builds the web UI locally
+  with `npm` and `rsync`s to the Pi — the Pi has no Node toolchain and is not
+  expected to get one. Any Linux/macOS machine with Node and Python 3.12.
+- **A microSD writer**, for the initial Ubuntu 24.04 LTS (`aarch64`) image.
+- **A hook and 2 m of cable route** to get the microphone under an eave. The
+  reference run goes out through a window jamb.
+- **Nothing soldered.** There is no soldering, no GPIO wiring, no breadboard in
+  this build. Everything is USB.
+
+---
+
+## Wanted later, not yet designed
+
+A **lux sensor** and a **rain sensor** — to say whether a detection happened in
+real darkness rather than calculated darkness, and to explain the hours where
+rain lifts the noise floor and quietens the birds. How to attach them is
+undecided; see Milestone 9 in
+[`docs/delivery/IMPLEMENTATION_PLAN.md`](docs/delivery/IMPLEMENTATION_PLAN.md).
+Do not buy these yet.
+
+---
+
+## Substitutions, and what they cost you
+
+| Instead of | You get | Verdict |
+|---|---|---|
+| An **AudioMoth recorder** running USB-Microphone firmware | A different USB device that must be reflashed; identity and switch behaviour differ. See [`docs/operations/AUDIOMOTH_FIRMWARE.md`](docs/operations/AUDIOMOTH_FIRMWARE.md). | Workable, but you are doing firmware work before you have a station. |
+| Any **48 kHz USB microphone** | Birds yes, bats **no**. The ultrasonic detector has nothing above Nyquist to detect. | Fine if you only want birds. Halves the point of the project. |
+| **Ultramic / Dodotronic** or similar | Untested here. The software addresses devices by name, not index, and records what it negotiated — so it may well work. | Unverified. No fixture test has passed on it, and this project does not call a detector "supported" without one. |
+| **microSD only**, no SSD | Clips and database on one card. | Works, wears the card out. The reference station moved clips to an SSD for exactly this reason. |
+| **A case with a fan** | Lower temperatures, and a fan near an ultrasonic microphone. | Don't, unless the fan is far from the mic. |
+| **Pi 4** | Untested. | Not recommended at 384 kHz. |
+
+---
+
+## Things worth knowing before you copy this
+
+These are the ones that actually cost time here.
+
+- **The AudioMoth's three-position switch matters.** `DEFAULT` streams audio;
+  `USB/OFF` is configuration-only and produces **no ALSA card at all**. Leaving
+  it in `USB/OFF` caused a 29-hour outage during commissioning.
+- **ALSA card numbers are not stable.** The AudioMoth moved from card 2 to card
+  0 across a reboot. Nothing in this codebase addresses a device by index, and
+  nothing you write should either.
+- **A microSD is not a good home for a continuously-writing database.** This one
+  is, for now. Storage endurance is a standing constraint in the charter.
+- **Microphone position affects the data more than any setting in this
+  repository.** Moving it a few feet changed the noise floor materially. Budget
+  more thought for where it hangs than for what you spend.
+- **Run `oo audio probe` before believing anything.** The station records what
+  it actually negotiated, not what the box claimed.
+
+For the full commissioning path, read
+[`docs/development/SETUP.md`](docs/development/SETUP.md) and
+[`docs/operations/DEPLOYMENT_AND_OPERATIONS.md`](docs/operations/DEPLOYMENT_AND_OPERATIONS.md).

--- a/README.md
+++ b/README.md
@@ -469,6 +469,10 @@ it is attached to and records what it actually negotiated (`oo audio probe`).
 It is listed because "what did you build it out of" is the first question
 anybody asks, and because a figure means more when you know what produced it.
 
+If you want to build one, [`BOM.md`](BOM.md) is the same list as a shopping
+list: quantities, rough prices, what is optional, what may be substituted, and
+the parts of this station you should *not* copy.
+
 | | What | Notes |
 |---|---|---|
 | Computer | Raspberry Pi 5 Model B Rev 1.1, 8 GB | Ubuntu 24.04 LTS, `aarch64` |

--- a/docs/api/DEBUG_UI_TRANSPORT.md
+++ b/docs/api/DEBUG_UI_TRANSPORT.md
@@ -528,6 +528,15 @@ While the station is not capturing from the real microphone, **no detections are
 sent at all** ([[ADR-020 - Non-live sources excluded|ADR-020]]). The `st`/`d` fields say why, and the display shows the
 banner. A test scene is not an observation of the garden.
 
+That test is `capture.is_live_hardware` and nothing else. It is **not** the `st`
+letter: a station can be degraded for a filling disk, a restarting detector or an
+operator pause, none of which makes what the microphone heard untrue. Gating on
+the letter cost six hours of feed on 2026-09-06 (issue #30) — the screen showed
+hours-old rows under a disk-usage banner while heartbeats kept arriving, so
+nothing looked stale. Suppressed detections are counted per client as
+`suppressed` in `/api/v1/station`, so a feed that has gone quiet on purpose can
+be told from one that has nothing to say.
+
 ### Back-pressure
 
 One bounded queue per client (`display_channel_queue_max`, default 64). When it
@@ -535,7 +544,7 @@ is full the **oldest detection frame** is shed — never a status frame, because
 losing the banner to a burst of woodpigeons would make a broken station look
 merely quiet, and never a `u` frame, for the same reason: a rollout that a burst
 of birdsong can silently cancel is not a rollout. Counters are reported in `/api/v1/station` under `display_channel`,
-including `mean_frame_bytes`.
+including `mean_frame_bytes` and `suppressed`.
 
 Capture always wins: nothing on this path can block or apply back-pressure to the
 capture loop.

--- a/docs/architecture/adr/ADR-020 - Non-live sources excluded.md
+++ b/docs/architecture/adr/ADR-020 - Non-live sources excluded.md
@@ -86,5 +86,24 @@ microphone against 1450.5 s captured. That is the `coverage` block carrying the
 explanation — the reason it is exempt from this filter — rather than this ADR's
 count.
 
+**2026-09-07 amendment.** Two of the gaps above are now closed on the display's
+socket, and one sentence of the review was wrong about it. The socket does not
+only "filter in SQL": its *live* half — `_pump_display` — applies the suppression
+per detection as well, and it was doing so against the wrong predicate. It gated
+on the display channel's degraded/listening letter rather than on the source, so
+an 85% disk watermark suppressed six hours of genuine, microphone-borne
+detections while the glass showed a banner about disk space (issue #30, recorded
+in [[ADR-038 - Display push channel|ADR-038]]). The gate is now
+`display_channel.detections_are_observations`, which asks `is_live_hardware` —
+the same predicate the MQTT publisher uses, and for the same reason: a live
+notification is a claim about the station *now*, not about a stored row. And the
+channel does now have somewhere to report a count: `suppressed` per client, in
+`/api/v1/station`'s `display_channel` block.
+
+The constraint above should be read as having two halves, not one. Applying the
+predicate is not enough; a surface that suppresses silently is indistinguishable
+from a surface with nothing to show, and on a device whose normal state *is*
+silence that difference is the whole signal.
+
 ---
 Part of the [[ADRS|Architecture Decision Record index]].

--- a/docs/architecture/adr/ADR-038 - Display push channel.md
+++ b/docs/architecture/adr/ADR-038 - Display push channel.md
@@ -200,7 +200,12 @@ server-side by the same decision tree the firmware runs for the fallback (so the
 two transports cannot describe one station differently); **offline** is a fact
 only the device can know, so the station never sends it. Detections are **not**
 pushed at all while the station is not on the real microphone ([[ADR-020 - Non-live sources excluded|ADR-020]]): the
-banner explains why, and the feed does not quietly fill with a test scene.
+banner explains why, and the feed does not quietly fill with a test scene. That
+gate reads the **capture source** (`detections_are_observations`), never the
+state letter. The two answer different questions — "is this a record of the
+garden?" and "is anything wrong with the station?" — and a station can be
+degraded for a dozen reasons that say nothing about whether the microphone heard
+what it heard. See the 2026-09-07 note below for what conflating them cost.
 
 **A stale feed must look stale, not merely quiet**, and on this device silence is
 the normal state — the absence of detections proves nothing. Only the 10 s
@@ -292,6 +297,49 @@ read:
   operations note, nothing in `docs/operations/`. The firmware README's "A fallback
   nobody ever runs is not a fallback" (`firmware/inside-observer/README.md:417`) is
   an argument for the design, not evidence that this one ran.
+
+**2026-09-07, issue #30 — a degraded station stopped feeding the glass.** The
+display was found showing rows five and six hours old under the banner "disk
+usage 86% exceeds the 85%", with "1 species today" in the footer and no staleness
+mark; a power cycle repopulated it instantly with nineteen species and rows
+seconds old. Nothing was wrong with the display, the Wi-Fi or the socket.
+
+`_pump_display` gated the ADR-020 suppression above on `health_state()`'s letter
+being `L`. When the station crossed its 85% retention watermark, `health_state`
+correctly returned `D` — and the pump read that as "not on the microphone" and
+dropped **every** detection, for as long as the disk stayed over the line. The
+heartbeat carried the same `D` onward every ten seconds, so the firmware's own
+staleness clock (three missed beats) never fired and the screen had no reason to
+look anything but calm. `species_today` froze too, because the tracker is only
+advanced on the frames that were not being sent. A reconnect looked like a cure
+because `_display_snapshot` reads the database directly and has never consulted
+health at all — so the screen refilled, and then froze again.
+
+Reproduced against the running station on 2026-09-07 before changing anything:
+health reported `is_live_hardware: true`, `source_kind: alsa`, `state: capturing`
+and `status: degraded` with the two watermark problems; a probe socket held open
+for 150 s received one hello (6 rows, `sp: 27`) and 14 heartbeats and **zero**
+detection frames, while the database recorded a *Spotted Flycatcher* at 0.93 in
+the same window.
+
+Two changes. The gate is now `display_channel.detections_are_observations`,
+which asks only `capture.is_live_hardware` — ADR-020's actual predicate, and the
+one the MQTT publisher has used all along (`mqtt/publisher.py:395`). And a
+suppressed detection is now counted per client and reported as `suppressed` in
+`/api/v1/station`'s `display_channel` block, because the six hours were invisible
+on the station as well as on the glass: nothing kept a tally, so there was
+nothing to ask afterwards.
+
+One thing the old gate covered by accident and the new one does not need to: a
+paused station ([[ADR-055 - Timed recording pause|ADR-055]]) suppresses its
+detections *before the event bus*, in `station.py:1215`, so nothing reaches this
+pump to gate in the first place. That is the right place for it — a consumer
+added to the bus later is paused by construction — and it is covered where it
+belongs (`tests/test_api.py:1742`), not here.
+
+The general lesson, and the one worth carrying: a health *summary* is for a
+person to read, not for a machine to branch on. Every consumer that needs to make
+a decision should ask the specific question it actually cares about.
 
 ---
 Part of the [[ADRS|Architecture Decision Record index]].

--- a/docs/operations/CAPTURE_RUN_2026-08-31.md
+++ b/docs/operations/CAPTURE_RUN_2026-08-31.md
@@ -1,0 +1,145 @@
+# Capture run 2026-08-31 to 2026-09-07 — 158.2 h unbroken, banked before a deploy
+
+The longest unbroken capture stream in this station's life: **158.204 hours**
+(6.59 days), more than double the 72.107 h that passed the acceptance soak on
+2026-08-25 ([[SOAK_2026-08-22]]).
+
+**Nobody staged this run either**, and it was never a scored soak. It began when
+`open-observatory.service` restarted on 2026-08-31 at 22:28 BST and simply kept
+going. It is written down here because it was about to be ended deliberately —
+the deploy carrying the [[ADR-038 - Display push channel|ADR-038]] display-feed
+fix (issue #30) restarts capture — and the counters behind it are process-scoped,
+so a restart erases them. Banking them costs a minute; losing them costs the
+longest clean window this station has produced.
+
+All figures read at `2026-09-07T11:40:18.995108Z`, 158.204 h in.
+
+## Validity — checked first, before any figure was recorded
+
+| check | required | measured |
+|---|---|---|
+| `started_utc` | unchanged | **2026-08-31T21:28:03.777446Z** |
+| `stream_id` | unchanged | `29ba4de4-a9aa-4d97-a01a-effc31a2c4d8` |
+| `stream_restarts` | 0 | **0** |
+| `clock_reanchors` | 0 | **0** |
+| `open_failures` | 0 | **0** |
+| `unclean_restart` | false | **false** |
+| `NRestarts` (systemd) | 0 | **0** |
+| elapsed | — | **158.204 h** |
+
+Host uptime at the same moment was **16 days 5 h**, dating to the 2026-08-22
+mains-cut reboot. The two numbers differ because the *service* was restarted on
+31 August while the machine was not, and confusing them is how a run gets
+credited with a week it did not have.
+
+## Against the five SLOs
+
+[[ADR-073 - Five capture SLOs]]. Drift is excluded from every loss SLO, as that
+ADR requires: the audio it describes exists and is fine.
+
+| | SLO | target | measured | |
+|---|---|---|---|---|
+| **B** | capture integrity | ≥ 99.99% (≤ 8.6 s/day) | **99.99962%**, 0.326 s/day | **pass**, 26× headroom |
+| **C** | timestamp accuracy | ≤ 60 s absolute | **29.04 s** and rising 4.41 s/day | **pass**, but see below |
+| **A/A2** | coverage | ≥ 99.5% / ≥ 99.9% | not scored — this is one stream, not a month | — |
+| **D** | detection coverage | ≥ 99% | not scored — the counters needed (`windows_in`, `windows_dropped`, `coverage_ratio`) all read `null` on `/api/v1/station` | — |
+| **E** | evidence sufficiency | ≥ 95% | not scored | — |
+
+Raw capture counters, for the record:
+
+| | |
+|---|---|
+| `continuity_ratio` | 0.999945 |
+| `capture_integrity_ratio` | 0.999996229 |
+| `audio_lost_seconds` | **2.1466** |
+| `drift_seconds` | 29.038 |
+| `discontinuities` / `gaps_with_loss` / `gaps_without_loss` | 4 / 4 / 0 |
+| `overruns` / `late_reads` / `late_read_max_frames` | 4 / 26 / 138,131 of 192,000 |
+| `hot_path_cpu_ratio` | 0.0232 |
+| `observed_rate_hz` / `rate_offset_ppm` | 383,980.437 / −50.94 |
+| `blocks` / `frames` | 5,691,719 / 218,562,009,600 |
+
+**SLO C is the reason this run could not have continued indefinitely.** At
+−50.9 ppm the stream accrues 4.41 s of timestamp error per day, so the 60 s bound
+falls at about **day 13.6** — 2026-09-14. ADR-073 says as much in the abstract
+("at 50 ppm this bounds a stream to ~14 days"); this is the first run to get far
+enough to make it a real date. The deploy resets it to zero, so ending the run
+here is not merely harmless to SLO C, it is the thing SLO C was going to require
+within a week anyway.
+
+## Every gap in the window
+
+Four, all `overrun`, all with loss. They reconcile **exactly** against the
+counter — 202,118 + 198,876 + 220,035 + 203,252 = **824,281 frames**, which is
+`estimated_missing_frames` to the frame, and 2.1466 s at 384 kHz.
+
+| when (UTC) | frames | duration | at frame | in the database? |
+|---|---|---|---|---|
+| 2026-09-04 01:37:23.829 | 202,118 | 0.5263 s | 105,271,526,400 | **no** |
+| 2026-09-06 22:10:07.698 | 198,876 | 0.5179 s | 200,023,833,600 | yes |
+| 2026-09-07 01:08:09.526 | 220,035 | 0.5730 s | 204,125,222,400 | **no** |
+| 2026-09-07 01:31:26.823 | 203,252 | 0.5293 s | 204,661,555,200 | **no** |
+
+Notably uniform: four overruns of about half a second each, where the 72-hour
+soak's two gaps were 0.04 s and 0.56 s. Three of the four are in the small hours
+(01:08, 01:31, 01:37) and one at 22:10, which is peak bat activity.
+
+## What this run found that the counters alone would not have
+
+### Three of the four gap records were never written
+
+`GET /api/v1/gaps` returns **one** row for this stream. The other three failed to
+insert with `sqlite3.OperationalError: database is locked`, logged as
+`capture.gap_row_failed` and then dropped — `_insert_gap_row` has no retry
+(`src/open_observatory/station.py:1175`).
+
+The in-memory counter is therefore the *only* honest account of this run's lost
+audio, and it dies with the process. The durable record — the one a person would
+consult next month — is missing 76% of it. The table above was reconstructed from
+the journal, which is why it is there.
+
+### 2,188 detections were lost to the same lock
+
+`persistence` reads `written: 402006, queued: 0, dropped: 0, failures: 2188`.
+Those 2,188 are detections that reached `_persist_loop`, hit `database is locked`,
+and were discarded — one attempt, no retry, gone
+(`src/open_observatory/station.py:1476`). That is **0.54% of all detections in the
+window**, permanently absent from the database.
+
+Worth stating plainly because of *which* counter stayed clean: `dropped: 0`. The
+queue never overflowed, so every back-pressure indicator this system has reads
+healthy. The loss is entirely inside `failures`, a counter nothing alerts on.
+
+### The lock contention is also why the disk is over its watermark
+
+6,585 "database is locked" occurrences in the window, alongside 1,099
+`retention.statement_interrupted` and 586
+`housekeeping.retention_never_reached_a_tier`. `retention.last_sweep_complete` is
+**false**, and disk stands at **85.55%** against an 85% watermark with
+581,232,352 bytes of it operator-kept recordings the sweep will not delete.
+
+That closes a circle worth drawing explicitly. The sweep cannot finish, so the
+disk crosses the watermark, so `/api/v1/health` reports a problem, so
+`display_channel.health_state` returns `D` — and until the fix that shipped with
+this deploy, a `D` letter stopped the counter-top display's feed entirely
+(issue #30). The frozen display was six hours downstream of SQLite lock
+contention.
+
+[[ADR-007 - SQLite in developer mode]] anticipated that SQLite would not be the
+production answer. This run is the first measurement of what it costs while it
+still is: 0.54% of detections, 76% of the gap record, and the retention sweep.
+
+## Not measured
+
+- **Coverage (SLO A/A2)** and **evidence sufficiency (SLO E)** — a single stream
+  cannot answer a monthly question.
+- **Detection coverage (SLO D)** — `/api/v1/station` reports `windows_analysed`
+  per detector but leaves `windows_in`, `windows_dropped` and `coverage_ratio`
+  `null`, so the ratio ADR-073 asks for cannot be computed from the surface that
+  is supposed to carry it. All three detectors reported `state: ok` with lag
+  around 31.2 s.
+- **Whether any of the four overruns cost a detection.** The gaps are half a
+  second each; nothing correlates them against detector windows.
+
+---
+Part of [[docs/operations]].

--- a/src/open_observatory/api/app.py
+++ b/src/open_observatory/api/app.py
@@ -2529,16 +2529,32 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     #: asking independently would not, and neither would a future one that
     #: reconnects in a loop. Cached briefly and shared, so the cost is bounded by
     #: the clock rather than by the number of clients.
-    display_health_cache: dict[str, Any] = {"at": 0.0, "value": ("L", "")}
+    #:
+    #: The banner and the feed gate are read off the *same* payload, in one
+    #: place, because they are two different questions about one moment and
+    #: answering them from two reads is how they drift apart.
+    display_health_cache: dict[str, Any] = {"at": 0.0, "value": ("L", "", True)}
 
-    def _display_health() -> tuple[str, str]:
+    def _display_status() -> tuple[str, str, bool]:
+        """The state letter, its banner line, and whether detections made right
+        now count as observations of the garden (ADR-020)."""
         now = time.monotonic()
         if now - display_health_cache["at"] > 5.0:
-            display_health_cache["value"] = display_state.health_state(_health_payload())
+            payload = _health_payload()
+            state, detail = display_state.health_state(payload)
+            display_health_cache["value"] = (
+                state,
+                detail,
+                display_state.detections_are_observations(payload),
+            )
             display_health_cache["at"] = now
         value = display_health_cache["value"]
         assert isinstance(value, tuple)
         return value
+
+    def _display_health() -> tuple[str, str]:
+        state, detail, _ = _display_status()
+        return state, detail
 
     def _display_day_key(moment: datetime | None = None) -> str:
         """Today, in the station's configured zone. UTC internally; local only
@@ -2765,19 +2781,34 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             if event is not None:
                 if event.get("event_type") == "_bus.closed":
                     return
-                state, _ = _display_health()
+                _, _, live = _display_status()
                 detection = event.get("data") or {}
                 # ADR-020: while the station is not on the real microphone its
                 # detections are records of a test scene, not observations of the
                 # garden. The banner already says so; the feed must not quietly
                 # keep filling with them.
-                if state == "L":
+                #
+                # The gate is the *source*, never the degraded letter. Those are
+                # different questions, and reading one for the other cost six
+                # hours of feed in issue #30: a disk watermark made the station
+                # degraded, this gate read that as "not listening", and every
+                # detection was dropped under a banner about disk space while the
+                # heartbeat kept the glass looking calm.
+                if live:
                     item = display_state.wire_item(detection, filt)
                     if item is not None:
                         tracker.observe(_display_day_key(), detection)
                         moved = tracker.count if tracker.count != last_sent_count else None
                         last_sent_count = tracker.count
                         client.offer(display_state.detection_frame(item, species_today=moved))
+                else:
+                    # Counted and logged, because the six hours above were
+                    # invisible on the station as well as on the glass: nothing
+                    # kept a tally, so there was nothing to ask afterwards. The
+                    # count rides out on `/api/v1/station` with the rest of this
+                    # client's numbers.
+                    client.suppressed += 1
+                    log.debug("display_channel.suppressed_non_live_detection")
             if time.monotonic() >= next_beat:
                 next_beat = time.monotonic() + heartbeat_s
                 state, detail = _display_health()

--- a/src/open_observatory/display_channel.py
+++ b/src/open_observatory/display_channel.py
@@ -354,6 +354,32 @@ def health_state(health: Mapping[str, Any]) -> tuple[str, str]:
     return "L", ""
 
 
+def detections_are_observations(health: Mapping[str, Any]) -> bool:
+    """Whether a detection made right now may be pushed to the glass.
+
+    ADR-020's predicate, and only ADR-020's predicate: is this station listening
+    to the microphone? A detection made against a synthetic scene or a replayed
+    fixture is a record of a test, not an observation of the garden, and must not
+    reach a surface a person reads as one. This is the same question the MQTT
+    publisher asks before it notifies Home Assistant, asked the same way.
+
+    It is deliberately *not* :func:`health_state`'s letter. Those answer
+    different questions and the difference cost six hours of feed on 2026-09-06:
+    the station crossed its 85% disk watermark, `health_state` correctly said
+    "D" for it, and the pump -- which was gating on that letter -- dropped every
+    detection while the heartbeat carried the same "D" onward, so the display
+    could not tell the silence from a quiet night. A filling disk, a restarting
+    detector and a paused station are all real faults worth a banner; none of
+    them makes what the microphone heard untrue.
+
+    Missing is not fine: a payload with no capture block cannot say where the
+    audio came from, and the safe reading of "unknown source" is the one that
+    does not present it as an observation.
+    """
+    capture = health.get("capture") or {}
+    return bool(capture.get("is_live_hardware", False))
+
+
 @dataclass
 class SpeciesToday:
     """The footer count, tracked incrementally instead of re-queried.
@@ -437,6 +463,11 @@ class DisplayClient:
         self.sent = 0
         self.dropped = 0
         self.bytes_sent = 0
+        #: Detections this client was not sent because the station was not on
+        #: the microphone (ADR-020). Distinct from `dropped`, which is a full
+        #: queue: this one is a deliberate refusal, and the number is the only
+        #: evidence a quiet feed was a decision rather than a quiet night.
+        self.suppressed = 0
 
     def offer(self, frame: Mapping[str, Any]) -> None:
         """Queue a frame. Never blocks, never raises, never awaits."""
@@ -483,6 +514,7 @@ class DisplayClient:
             "queued": self.queue_depth,
             "sent": self.sent,
             "dropped": self.dropped,
+            "suppressed": self.suppressed,
             "bytes_sent": self.bytes_sent,
             "mean_frame_bytes": round(self.bytes_sent / self.sent, 1) if self.sent else None,
             "firmware_version": self.firmware_version,

--- a/tests/test_display_channel.py
+++ b/tests/test_display_channel.py
@@ -19,6 +19,7 @@ from open_observatory.display_channel import (
     DisplayFilter,
     SpeciesToday,
     detection_frame,
+    detections_are_observations,
     encode,
     health_state,
     hello_frame,
@@ -283,6 +284,58 @@ class TestHealthState:
         )
         assert state == "D"
         assert detail == "CAPTURE stopped"
+
+
+class TestDetectionsAreObservations:
+    """The gate on whether a detection may be pushed to the glass.
+
+    Deliberately *not* the degraded letter. Issue #30: the station crossed its
+    85% disk watermark, `health_state` correctly returned "D" for it, and the
+    pump -- which was gating on that letter -- stopped pushing every detection
+    for six hours while the heartbeat kept the screen looking calm. A disk that
+    is filling up says nothing at all about whether what the microphone heard
+    was real. ADR-020's predicate is the source, and only the source, which is
+    what the MQTT publisher has always used.
+    """
+
+    def test_a_live_microphone_is_an_observation(self):
+        assert detections_are_observations(
+            {
+                "status": "ok",
+                "problems": [],
+                "capture": {"state": "capturing", "source_kind": "alsa", "is_live_hardware": True},
+            }
+        )
+
+    def test_a_disk_watermark_does_not_stop_the_feed(self):
+        health = {
+            "status": "degraded",
+            "problems": [
+                "disk usage 86% exceeds the 85% watermark and the retention sweep is not keeping up"
+            ],
+            "capture": {"state": "capturing", "source_kind": "alsa", "is_live_hardware": True},
+        }
+        assert health_state(health)[0] == "D"  # the banner is still right
+        assert detections_are_observations(health)  # and the feed still flows
+
+    def test_a_synthetic_source_is_not_an_observation(self):
+        assert not detections_are_observations(
+            {
+                "status": "degraded",
+                "problems": [],
+                "capture": {
+                    "state": "capturing",
+                    "source_kind": "synthetic",
+                    "is_live_hardware": False,
+                },
+            }
+        )
+
+    def test_an_absent_capture_block_is_not_an_observation(self):
+        """Unknown is not the same as fine. A health payload that cannot say
+        where the audio came from must not be read as saying it came from the
+        microphone."""
+        assert not detections_are_observations({"status": "ok", "problems": []})
 
 
 class TestSpeciesToday:

--- a/tests/test_display_endpoint.py
+++ b/tests/test_display_endpoint.py
@@ -116,18 +116,82 @@ class TestConnect:
         assert display_client.get("/api/v1/station").json()["display_channel"]["clients"] == 0
 
 
-class TestLiveDeltas:
-    """With the station reporting healthy, detections must actually flow.
+class TestDegradedForSomethingElse:
+    """Issue #30. A station can be degraded for a reason that has nothing to do
+    with the microphone, and the feed must keep flowing while it says so.
 
-    `health_state` is patched rather than the hardware faked: the source really
-    is synthetic here, and pretending otherwise anywhere else in the app would be
-    exactly the dishonesty ADR-020 forbids. This narrows the pretence to the one
-    function whose output the pump consults.
+    What happened: disk crossed the 85% watermark, `health_state` returned "D"
+    with the watermark's own wording, and the pump -- gating on that letter --
+    dropped every detection for six hours. The heartbeat kept arriving carrying
+    the same "D", so the display's own staleness clock never fired and the glass
+    showed six-hour-old rows under a disk banner with nothing to say it had
+    stopped listening. A power cycle repopulated it instantly, because the
+    connect snapshot reads the database and has never consulted health at all.
+
+    The source really is synthetic in this fixture, so `detections_are_observations`
+    is the one function pretended at -- the same narrowing `TestLiveDeltas` makes,
+    and for the same reason.
     """
 
     @pytest.fixture(autouse=True)
-    def _healthy(self, monkeypatch):
-        monkeypatch.setattr(display_channel, "health_state", lambda _health: ("L", ""))
+    def _degraded_but_listening(self, monkeypatch):
+        monkeypatch.setattr(
+            display_channel,
+            "health_state",
+            lambda _health: ("D", "disk usage 86% exceeds the 85% watermark"),
+        )
+        monkeypatch.setattr(display_channel, "detections_are_observations", lambda _health: True)
+
+    def test_detections_still_reach_a_degraded_station_s_display(self, display_client) -> None:
+        with display_client.websocket_connect("/api/v1/display") as socket:
+            _receive(socket, "h")
+            frame, _ = _receive(socket, "d", tries=200)
+            assert frame["at"] > 1_600_000_000
+
+    def test_the_banner_still_says_what_is_wrong(self, display_client) -> None:
+        with display_client.websocket_connect("/api/v1/display") as socket:
+            frame, _ = _receive(socket, "h")
+            assert frame["st"] == "D"
+            assert frame["d"] == "disk usage 86% exceeds the 85% watermark"
+
+
+class TestSuppressionIsCounted:
+    """A detection dropped for ADR-020 must leave a trace.
+
+    The six hours in issue #30 were invisible everywhere, not just on the glass:
+    the pump dropped each detection with no counter and no log line, so nothing
+    on the station could be asked what had happened either. The fixture's source
+    is genuinely synthetic, so suppression here is the correct behaviour and the
+    count is the evidence of it.
+    """
+
+    def test_suppressed_detections_are_reported_on_the_station_snapshot(
+        self, display_client
+    ) -> None:
+        with display_client.websocket_connect("/api/v1/display") as socket:
+            _receive(socket, "h")
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                socket.receive_text()  # heartbeats; the deltas are being suppressed
+                stats = display_client.get("/api/v1/station").json()["display_channel"]
+                if stats["per_client"] and stats["per_client"][0]["suppressed"] > 0:
+                    return
+            raise AssertionError("nothing recorded that detections were being dropped")
+
+
+class TestLiveDeltas:
+    """With the station on the microphone, detections must actually flow.
+
+    `detections_are_observations` is patched rather than the hardware faked: the
+    source really is synthetic here, and pretending otherwise anywhere else in
+    the app would be exactly the dishonesty ADR-020 forbids. This narrows the
+    pretence to the one function whose output the pump's gate consults -- which
+    is the source predicate, not the state letter, since issue #30.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _on_the_microphone(self, monkeypatch):
+        monkeypatch.setattr(display_channel, "detections_are_observations", lambda _health: True)
 
     def test_a_bat_pass_arrives_as_a_delta_with_no_name_and_no_score(
         self, display_client


### PR DESCRIPTION
Fixes #30.

## What happened

The counter-top display was found showing rows five and six hours old under a `disk usage 86% exceeds the 85%` banner, with no staleness mark and "1 species today" in the footer. A power cycle repopulated it instantly with nineteen species and rows seconds old.

Nothing was wrong with the display, the Wi-Fi or the socket.

`_pump_display` gated ADR-020's non-live suppression on `health_state()` returning `L`. When the station crossed its 85% retention watermark, `health_state` correctly returned `D` — and the pump read that as *not on the microphone* and dropped **every** detection for as long as the disk stayed over the line. The heartbeat carried the same `D` onward every ten seconds, so the firmware's staleness clock (three missed beats) never fired and the glass had no reason to look anything but calm. `species_today` froze with it, because the tracker only advances on frames that were being sent. The reconnect looked like a cure because `_display_snapshot` reads the database directly and has never consulted health at all — so the screen refilled, then froze again.

## Reproduced before changing anything

Against the running station: health reported `is_live_hardware: true`, `source_kind: alsa`, `state: capturing`, `status: degraded` with two watermark problems. A probe socket held open for 150 s received one hello (6 rows, `sp: 27`) and 14 heartbeats and **zero** detection frames — while the database recorded a *Spotted Flycatcher* at 0.93 in the same window.

## The fix

- The gate is now `display_channel.detections_are_observations`, which asks `capture.is_live_hardware` and nothing else. That is ADR-020's actual predicate, and the one the MQTT publisher has used all along (`mqtt/publisher.py:395`). A filling disk, a restarting detector and a paused station are all worth a banner; none of them makes what the microphone heard untrue.
- Suppressed detections are counted per client and reported as `suppressed` on `/api/v1/station`. The six hours were invisible on the station as well as on the glass — nothing kept a tally, so there was nothing to ask afterwards.
- The banner and the gate are now read off one cached health payload, so they cannot drift apart.

## For a reviewer

- **`TestLiveDeltas` changed on purpose.** It patched `health_state` to `("L", "")` to make deltas flow; that no longer controls the gate, so it now patches `detections_are_observations`. The fixture's own docstring explains why the pretence is narrowed to exactly one function.
- **A paused station is unaffected.** ADR-055 suppresses before the event bus (`station.py:1215`), so nothing reaches this pump to gate. The old letter-gate covered pause by accident; the new one doesn't need to. Covered where it belongs, at `tests/test_api.py:1742`.
- **Deployed and verified on the Pi.** New gate live, display reconnected on firmware 0.2.5, a *Eurasian Jackdaw* pushed through the same probe socket that got nothing before. Caveat: the disk problem cleared on restart (`last_sweep_complete` resets), so the fix has not yet been watched under a genuinely degraded station. The tests cover that path and `suppressed` is the field to check in the field.
- Full suite: 1130 passed, 9 skipped (12 deselected — the known `TestLiveChannels` hang). Ruff and mypy clean.

## Also in this branch

**`docs/operations/CAPTURE_RUN_2026-08-31.md`** — the 158.2 h capture stream this deploy ended, banked before restarting it. Longest this station has produced, more than double the 72.107 h that passed the soak: capture integrity 99.99962%, zero restarts, four overrun gaps totalling 2.1466 s.

Reconstructing those four gaps found two things worth more attention than the display bug, both **untouched by this PR**:

- **Three of the four gap records were never written to the database** — `sqlite3.OperationalError: database is locked`, logged and dropped, no retry in `_insert_gap_row`. The durable record is missing 76% of the run's lost audio.
- **2,188 detections (0.54% of the window) were lost the same way** in `_persist_loop` — one attempt, no retry. `persistence.dropped` reads `0` throughout, so every back-pressure indicator looks healthy; the loss lives in `failures`, which nothing alerts on.

The same contention interrupts the retention sweep, which is why the disk crossed the watermark that put the station into `D` in the first place. The frozen display was six hours downstream of SQLite lock contention. ADR-007 anticipated SQLite would not be the production answer; this is the first measurement of what it costs while it still is.

The BOM commit (`12cbef9`) was made on this branch outside the fix work and rides along.

Left uncommitted deliberately: `AGENTS.md` (untracked) and `docs/.obsidian/workspace.json` (editor pane state) both predate this work and are unrelated — whether `AGENTS.md` should be tracked is a call for its author, not something to sweep into a bugfix PR.